### PR TITLE
Fixed long whitespace in Labs, Project & Lecture page

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -6749,14 +6749,14 @@ button.close {
   background-color: #f1eaea;
 }
 body {
-  min-height: 2000px;
+  min-height: auto;
   padding-top: 70px;
   font-family: Arial, Helvetica, sans-serif;
   text-align: justify;
 }
 footer {
   margin: 0px auto;
-  margin-top: 20px;
+  margin-top: 50px;
   width: 800px;
 }
 p,


### PR DESCRIPTION
There is a long whitespace in bottom of certain pages with no contents being in it (Labs, Project & Lecture). 

Fixed the long whitespace in certain pages as the style.css had a predefined 2000px minimum height. I have also increased the top-margin for the footer so it does not look like it is part of the same element as the main contents. 