### PR TITLE
Update deliverable 2 rubric to 2018 version

### DIFF
--- a/_data/project.yml
+++ b/_data/project.yml
@@ -18,8 +18,8 @@
 - week: Project Requirement
   handout: 02/
   rubric:
-    - deliverable: https://grademy.work/rubric?id=C01F17-D2
-    - interview: https://grademy.work/rubric?id=C01F17-I2
+    - deliverable: https://grademy.work/rubric?id=C01F18-D2
+    - interview: https://grademy.work/rubric?id=C01F18-I2
 
 - week: 
     


### PR DESCRIPTION
The website's link to the deliverable rubric is currently linked to the 2017 version of grademy.work. This PR changes the link to the 2018 version.